### PR TITLE
Feature/#26/redis auth code storage

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -51,3 +51,6 @@ HELP.md
 
 # 민감한 정보가 들어있는 secret.properties 파일을 무시
 src/main/resources/secret.properties
+
+# Redis 서버의 메모리 상태를 저장한 파일
+dump.rdb

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail:3.3.5'
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.eclipse.angus:jakarta.mail:1.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/server/src/main/java/com/wap/wapor/controller/EmailController.java
+++ b/server/src/main/java/com/wap/wapor/controller/EmailController.java
@@ -3,6 +3,7 @@ package com.wap.wapor.controller;
 import com.wap.wapor.dto.EmailCheck;
 import com.wap.wapor.dto.EmailLoginRequest;
 import com.wap.wapor.exception.AuthCodeMismatchException;
+import com.wap.wapor.dto.EmailSignUpRequest;
 import com.wap.wapor.service.EmailSendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,7 @@ public class EmailController {
 
     // 이메일 인증 번호 전송
     @PostMapping("/mailSend")
-    public ResponseEntity<String> mailSend(@RequestBody @Valid EmailLoginRequest emailRequest) {
+    public ResponseEntity<String> mailSend(@RequestBody @Valid EmailSignUpRequest emailRequest) {
         String authCode = emailService.joinEmail(emailRequest.getIdentifier());  // 인증 번호 전송
         return ResponseEntity.ok("인증 번호가 전송되었습니다. 인증 번호: " + authCode);
     }

--- a/server/src/main/java/com/wap/wapor/controller/EmailController.java
+++ b/server/src/main/java/com/wap/wapor/controller/EmailController.java
@@ -1,8 +1,6 @@
 package com.wap.wapor.controller;
 
 import com.wap.wapor.dto.EmailCheck;
-import com.wap.wapor.dto.EmailLoginRequest;
-import com.wap.wapor.exception.AuthCodeMismatchException;
 import com.wap.wapor.dto.EmailSignUpRequest;
 import com.wap.wapor.service.EmailSendService;
 import lombok.RequiredArgsConstructor;
@@ -19,14 +17,14 @@ public class EmailController {
     // 이메일 인증 번호 전송
     @PostMapping("/mailSend")
     public ResponseEntity<String> mailSend(@RequestBody @Valid EmailSignUpRequest emailRequest) {
-        String authCode = emailService.joinEmail(emailRequest.getIdentifier());  // 인증 번호 전송
+        String authCode = emailService.requestAuthCode(emailRequest.getIdentifier());  // 인증 번호 전송
         return ResponseEntity.ok("인증 번호가 전송되었습니다. 인증 번호: " + authCode);
     }
 
     // 인증 번호 확인
     @PostMapping("/mailAuthCheck")
     public ResponseEntity<String> authCheck(@RequestBody @Valid EmailCheck emailCheck) {
-        emailService.verifyAuthCode(emailCheck.getAuthCode());
+        emailService.verifyAuthCode(emailCheck.getIdentifier(), emailCheck.getAuthCode());
         return ResponseEntity.ok("인증 번호가 일치합니다.");
     }
 }

--- a/server/src/main/java/com/wap/wapor/dto/EmailCheck.java
+++ b/server/src/main/java/com/wap/wapor/dto/EmailCheck.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotEmpty;
 public class EmailCheck {
     @Email
     @NotEmpty(message = "이메일을 입력해 주세요")
-    private String email;
+    private String identifier;
 
     @NotEmpty(message = "인증 번호를 입력해 주세요")
     private String authCode;

--- a/server/src/main/java/com/wap/wapor/dto/EmailSignUpRequest.java
+++ b/server/src/main/java/com/wap/wapor/dto/EmailSignUpRequest.java
@@ -1,0 +1,11 @@
+package com.wap.wapor.dto;
+
+import com.wap.wapor.domain.UserType;
+import lombok.Data;
+
+@Data
+public class EmailSignUpRequest {
+    private UserType userType;
+    private String password;
+    private String identifier;
+}

--- a/server/src/main/java/com/wap/wapor/exception/AuthCodeExpiredException.java
+++ b/server/src/main/java/com/wap/wapor/exception/AuthCodeExpiredException.java
@@ -1,0 +1,7 @@
+package com.wap.wapor.exception;
+
+public class AuthCodeExpiredException extends RuntimeException {
+    public AuthCodeExpiredException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/wap/wapor/exception/EmailNotFoundException.java
+++ b/server/src/main/java/com/wap/wapor/exception/EmailNotFoundException.java
@@ -1,0 +1,7 @@
+package com.wap.wapor.exception;
+
+public class EmailNotFoundException extends RuntimeException {
+    public EmailNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/wap/wapor/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/wap/wapor/exception/GlobalExceptionHandler.java
@@ -20,13 +20,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이메일 유효성 오류: " + ex.getMessage());
     }
 
-
-    // 4. 인증번호 불일치 오류 처리
+    // 3. 인증번호 불일치 오류 처리
     @ExceptionHandler(AuthCodeMismatchException.class)
     public ResponseEntity<String> handleAuthCodeMismatchException(AuthCodeMismatchException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 번호 불일치: " + ex.getMessage());
     }
 
+    // 4. 제한 시간 만료 오류 처리
+    @ExceptionHandler(AuthCodeExpiredException.class)
+    public ResponseEntity<String> handleAuthCodeExpiredException(AuthCodeExpiredException ex) {
+        return ResponseEntity.status(HttpStatus.GONE).body("제한 시간 만료: " + ex.getMessage());
+    }
+
+    // 5. Redis 서버 연결 오류 처리
+    @ExceptionHandler(RedisConnectionException.class)
+    public ResponseEntity<String> handleRedisConnectionException(RedisConnectionException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("Redis 서버 연결 오류: " + ex.getMessage());
+    }
 
     // 그 외 모든 예외 처리
     @ExceptionHandler(Exception.class)

--- a/server/src/main/java/com/wap/wapor/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/wap/wapor/exception/GlobalExceptionHandler.java
@@ -23,16 +23,22 @@ public class GlobalExceptionHandler {
     // 3. 인증번호 불일치 오류 처리
     @ExceptionHandler(AuthCodeMismatchException.class)
     public ResponseEntity<String> handleAuthCodeMismatchException(AuthCodeMismatchException ex) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 번호 불일치: " + ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 번호 오류: " + ex.getMessage());
     }
 
-    // 4. 제한 시간 만료 오류 처리
+    // 4. 인증번호 만료 오류 처리 (제한 시간 만료)
     @ExceptionHandler(AuthCodeExpiredException.class)
     public ResponseEntity<String> handleAuthCodeExpiredException(AuthCodeExpiredException ex) {
-        return ResponseEntity.status(HttpStatus.GONE).body("제한 시간 만료: " + ex.getMessage());
+        return ResponseEntity.status(HttpStatus.GONE).body("제한 시간 오류: " + ex.getMessage());
     }
 
-    // 5. Redis 서버 연결 오류 처리
+    // 5. 이메일이 존재하지 않을 때의 오류 처리
+    @ExceptionHandler(EmailNotFoundException.class)
+    public ResponseEntity<String> handleEmailNotFoundException(EmailNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("이메일 조회 오류: " + ex.getMessage());
+    }
+
+    // 6. Redis 서버 연결 오류 처리
     @ExceptionHandler(RedisConnectionException.class)
     public ResponseEntity<String> handleRedisConnectionException(RedisConnectionException ex) {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("Redis 서버 연결 오류: " + ex.getMessage());

--- a/server/src/main/java/com/wap/wapor/exception/RedisConnectionException.java
+++ b/server/src/main/java/com/wap/wapor/exception/RedisConnectionException.java
@@ -1,0 +1,7 @@
+package com.wap.wapor.exception;
+
+public class RedisConnectionException extends RuntimeException {
+    public RedisConnectionException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/wap/wapor/service/EmailSendService.java
+++ b/server/src/main/java/com/wap/wapor/service/EmailSendService.java
@@ -1,9 +1,10 @@
 package com.wap.wapor.service;
 
-import com.wap.wapor.exception.AuthCodeMismatchException;
-import com.wap.wapor.exception.CustomMailSendException;
-import com.wap.wapor.exception.EmailValidationException;
+import com.wap.wapor.exception.*;
+import com.wap.wapor.util.RedisUtil;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -16,32 +17,35 @@ import jakarta.mail.internet.MimeMessage;
 public class EmailSendService {
 
     private final JavaMailSender mailSender;
-    private String authCode;  // 임시로 인증 번호를 저장할 변수
+    private final RedisUtil redisUtil;
+    private final StringRedisTemplate stringRedisTemplate; // StringRedisTemplate 추가
 
     @Value("${spring.mail.username}")
     private String setFrom;
 
-    public EmailSendService(JavaMailSender mailSender) {
+    @Autowired
+    public EmailSendService(JavaMailSender mailSender, RedisUtil redisUtil, StringRedisTemplate stringRedisTemplate) {
         this.mailSender = mailSender;
+        this.redisUtil = redisUtil;
+        this.stringRedisTemplate = stringRedisTemplate; // 생성자 주입
     }
 
-    // 인증 번호 생성 메서드
-    public void createAuthCode() {
-        this.authCode = String.format("%06d", (int)(Math.random() * 900000) + 100000);  // 6자리 인증 번호 생성
-    }
-
-    // 인증 번호 생성 후 이메일 전송
-    public String joinEmail(String email) {
-        createAuthCode(); // 인증 번호 생성
+    // 인증 번호 생성 및 Redis에 저장 메서드
+    public String requestAuthCode(String identifier) {
+        String authCode = generateAuthCode();  // 인증 번호 생성
         String title = "[WAPOR] 회원 가입 인증 번호 요청 메일입니다.";
         String content = "회원 가입 인증 번호입니다." + "<br><br>" + authCode + "<br>" + "인증 번호를 정확하게 입력해 주세요.";
 
-        mailSend(setFrom, email, title, content);  // 이메일 전송
-        return authCode;    // 생성된 인증 번호 반환 (확인용)
+        // Redis에 인증 번호 저장 (key: authCode:<identifier>, 만료 시간: 5분)
+        redisUtil.setDataExpire("authCode:" + identifier, authCode);
+
+        // 이메일 전송
+        sendEmail(setFrom, identifier, title, content);
+        return authCode;  // 확인용으로 반환 (실제 서비스에서는 보통 반환하지 않음)
     }
 
     // 이메일 전송 메서드
-    public void mailSend(String setFrom, String toMail, String title, String content) {
+    private void sendEmail(String setFrom, String toMail, String title, String content) {
         MimeMessage message = mailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");
@@ -57,11 +61,36 @@ public class EmailSendService {
         }
     }
 
-    // 인증 번호 확인 메서드
-    public boolean verifyAuthCode(String inputAuthCode) {
-        if (authCode == null || !authCode.equals(inputAuthCode)) {
-            throw new AuthCodeMismatchException("인증 번호를 다시 확인해 주세요.");
+    // 인증 번호 생성 메서드
+    private String generateAuthCode() {
+        return String.format("%06d", (int) (Math.random() * 900000) + 100000); // 6자리 인증 번호
+    }
+
+    // 인증 번호 검증 메서드
+    public boolean verifyAuthCode(String identifier, String inputAuthCode) {
+        String key = "authCode:" + identifier;
+
+        // 1. 키의 TTL을 확인하여 존재 여부와 만료 여부를 확인
+        Long ttl = stringRedisTemplate.getExpire(key);
+
+        if (ttl == null || ttl == -2) {
+            // 키가 아예 존재하지 않는 경우 - 이메일이 존재하지 않음
+            throw new EmailNotFoundException("이메일이 존재하지 않습니다.");
+        } else if (ttl == 0) {
+            // 키는 존재하지만 TTL이 설정되어 있지 않은 경우 - 만료된 경우로 간주
+            throw new AuthCodeExpiredException("인증 번호가 만료되었습니다.");
         }
+
+        // 2. Redis에서 인증 코드 조회
+        String storedAuthCode = redisUtil.getData(key);
+
+        if (!storedAuthCode.equals(inputAuthCode)) {
+            // 입력된 인증 번호와 저장된 인증 번호가 일치하지 않는 경우 예외 처리
+            throw new AuthCodeMismatchException("인증 번호가 일치하지 않습니다.");
+        }
+
+        // 인증 성공 시 Redis에서 키 삭제
+        redisUtil.deleteData(key);
         return true;
     }
 }

--- a/server/src/main/java/com/wap/wapor/util/RedisUtil.java
+++ b/server/src/main/java/com/wap/wapor/util/RedisUtil.java
@@ -1,0 +1,35 @@
+package com.wap.wapor.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // 키를 통해 Redis에서 값을 조회
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        String result = valueOperations.get(key);
+        System.out.println("Redis에서 조회한 키: " + key + ", 값: " + result);
+        return result;
+    }
+
+    // 유효 시간 동안(key, value) 저장 (TTL 5분)
+    public void setDataExpire(String key, String value) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofMinutes(5);
+        System.out.println("Redis에 저장하는 키: " + key + ", 값: " + value);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    // key를 통해 데이터 삭제
+    public void deleteData(String key) {
+        stringRedisTemplate.delete(key);
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.mail.port=587
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+


### PR DESCRIPTION
### #️⃣ Related Issue
해결한 이슈 번호 
> ex) #이슈번호, #이슈번호

#26 

### 📝 Key Changes 
주요 구현 사항
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/8b098283-eb93-4279-ba6f-c0736b8763ba)

인증 번호를 redis 데이터베이스에 저장하여 조회하고 검증하는 로직을 구현했습니다.
이메일 유효성 검사 dto에서 필드 이름이 identifier가 아니라 email으로 잘못 작성한 탓에 오류가 있었지만 해결했습니다.

### 💬 To Reviewers
리뷰어에게 전달할 말
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?