### PR TITLE
Feature/#33/virtual account

### DIFF
--- a/server/src/main/java/com/wap/wapor/config/SecurityConfig.java
+++ b/server/src/main/java/com/wap/wapor/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
 
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth 
-                        .requestMatchers("/auth/kakao","/auth/kakao/callback","/mailSend", "/mailAuthCheck", "/api/users/register/email", "/api/users/login/email").permitAll() // 인증 없이 접근 허용
+                        .requestMatchers("/auth/kakao","/auth/kakao/callback","/mailSend", "/mailAuthCheck", "/api/users/register/email", "/api/users/login/email", "/api/virtual-account/deposit").permitAll() // 인증 없이 접근 허용
                         .anyRequest().authenticated() // 그 외의 모든 요청은 인증 필요
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/server/src/main/java/com/wap/wapor/controller/VirtualAccountController.java
+++ b/server/src/main/java/com/wap/wapor/controller/VirtualAccountController.java
@@ -1,0 +1,26 @@
+package com.wap.wapor.controller;
+
+import com.wap.wapor.domain.VirtualAccount;
+import com.wap.wapor.dto.DepositRequest;
+import com.wap.wapor.service.VirtualAccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/virtual-account")
+@RequiredArgsConstructor
+public class VirtualAccountController {
+
+    private final VirtualAccountService virtualAccountService;
+
+    @PostMapping("/deposit")
+    public ResponseEntity<VirtualAccount> deposit(@RequestBody DepositRequest request) {
+        VirtualAccount updatedAccount = virtualAccountService.deposit(
+                request.getAccountId(),
+                request.getAmount(),
+                request.getIdentifier()
+        );
+        return ResponseEntity.ok(updatedAccount);
+    }
+}

--- a/server/src/main/java/com/wap/wapor/domain/Likes.java
+++ b/server/src/main/java/com/wap/wapor/domain/Likes.java
@@ -9,19 +9,19 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"post_id", "user_id"})})
+@Table(name = "likes", uniqueConstraints = {@UniqueConstraint(columnNames = {"paylog_id", "user_id"})}) // 테이블 및 유니크 제약 조건 수정
 public class Likes {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // like_id (Primary Key)
+    @Column(name = "id") // snake_case 매핑
+    private Long id; // Primary Key
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "paylog_id", nullable = false)
+    @JoinColumn(name = "paylog_id", nullable = false) // snake_case로 외래 키 매핑
     private PayLog payLog; // 게시글 (FK)
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false) // snake_case로 외래 키 매핑
     private User user; // 좋아요를 누른 사용자 (FK)
-
 }

--- a/server/src/main/java/com/wap/wapor/domain/PayLog.java
+++ b/server/src/main/java/com/wap/wapor/domain/PayLog.java
@@ -16,25 +16,39 @@ public class PayLog {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // post_id (Primary Key)
+    @Column(name = "id") // snake_case와 매핑
+    private Long id; // Primary Key
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false) // snake_case로 외래 키 매핑
     private User user; // 작성자 정보 (FK)
 
+    @Column(name = "content") // snake_case로 매핑
     private String content; // 게시글 내용
-    private String title;   //게시글 제목
+
+    @Column(name = "title") // snake_case로 매핑
+    private String title; // 게시글 제목
+
+    @Column(name = "category") // snake_case로 매핑
     private String category; // 카테고리
 
+    @Column(name = "amount") // snake_case로 매핑
     private Long amount; // 금액
 
+    @Column(name = "created_at", nullable = false, updatable = false) // snake_case로 매핑
     private LocalDateTime createdAt; // 작성 시간
 
+    @Column(name = "img_url") // snake_case로 매핑
     private String imgUrl; // 첨부 이미지 URL
 
+    @Column(name = "like_count") // snake_case로 매핑
     private int likeCount = 0; // 좋아요 수 (캐싱)
 
     @OneToMany(mappedBy = "payLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Likes> likes; // 좋아요 리스트
-}
 
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now(); // 작성 시간 기본값 설정
+    }
+}

--- a/server/src/main/java/com/wap/wapor/domain/Transaction.java
+++ b/server/src/main/java/com/wap/wapor/domain/Transaction.java
@@ -8,22 +8,24 @@ import java.time.LocalDateTime;
 @Entity
 @Data
 public class Transaction {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transaction_id") // snake_case로 데이터베이스 필드와 매핑
     private Long transactionId; // 거래 ID (Primary Key)
 
     @ManyToOne
-    @JoinColumn(name = "accountId", nullable = false)
+    @JoinColumn(name = "account_id", nullable = false) // snake_case로 외래 키 매핑
     private VirtualAccount virtualAccount; // VirtualAccount 테이블과 N:1 관계 (외래 키)
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "transaction_type", nullable = false) // 거래 유형 필드 매핑
     private TransactionType transactionType; // 거래 유형 (DEPOSIT/WITHDRAWAL)
 
-    @Column(nullable = false)
+    @Column(name = "amount", nullable = false) // 거래 금액 매핑
     private Long amount; // 거래 금액
 
-    @Column(nullable = false)
+    @Column(name = "transaction_date", nullable = false) // 거래 발생 시간 매핑
     private LocalDateTime transactionDate; // 거래 발생 시간
 
     @PrePersist

--- a/server/src/main/java/com/wap/wapor/domain/Transaction.java
+++ b/server/src/main/java/com/wap/wapor/domain/Transaction.java
@@ -1,0 +1,33 @@
+package com.wap.wapor.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+public class Transaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long transactionId; // 거래 ID (Primary Key)
+
+    @ManyToOne
+    @JoinColumn(name = "accountId", nullable = false)
+    private VirtualAccount virtualAccount; // VirtualAccount 테이블과 N:1 관계 (외래 키)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionType transactionType; // 거래 유형 (DEPOSIT/WITHDRAWAL)
+
+    @Column(nullable = false)
+    private Long amount; // 거래 금액
+
+    @Column(nullable = false)
+    private LocalDateTime transactionDate; // 거래 발생 시간
+
+    @PrePersist
+    protected void onCreate() {
+        this.transactionDate = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/wap/wapor/domain/TransactionType.java
+++ b/server/src/main/java/com/wap/wapor/domain/TransactionType.java
@@ -1,0 +1,6 @@
+package com.wap.wapor.domain;
+
+public enum TransactionType {
+    DEPOSIT, // 입금
+    WITHDRAWAL // 출금
+}

--- a/server/src/main/java/com/wap/wapor/domain/User.java
+++ b/server/src/main/java/com/wap/wapor/domain/User.java
@@ -9,16 +9,14 @@ import lombok.Data;
 @Entity
 @Data
 public class User {
+
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userId;
+    @Column(nullable = false, unique = true)
+    private String identifier; // Kakao ID or Email address, Primary Key로 사용
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserType userType; // 사용자의 유형(KAKAO/EMAIL)
-
-    @Column(nullable = false, unique = true)
-    private String identifier; // Kakao ID or Email address
 
     @Column(nullable = true) // 카카오 회원은 null
     private String password;

--- a/server/src/main/java/com/wap/wapor/domain/VirtualAccount.java
+++ b/server/src/main/java/com/wap/wapor/domain/VirtualAccount.java
@@ -10,19 +10,20 @@ import java.time.LocalDateTime;
 public class VirtualAccount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_id") // snake_case와 일치
     private Long accountId; // 계좌 ID (Primary Key)
 
-    @Column(nullable = false)
+    @Column(name = "balance", nullable = false)
     private Long balance; // 잔액 (기본값 0)
 
-    @Column(nullable = false, updatable = false)
+    @Column(name = "create_at", nullable = false, updatable = false)
     private LocalDateTime createAt; // 생성 시간
 
-    @Column(nullable = true)
+    @Column(name = "update_at", nullable = true)
     private LocalDateTime updateAt; // 갱신 시간
 
     @OneToOne
-    @JoinColumn(name = "userId", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false, unique = true) // user_id로 수정
     private User user; // User 테이블과 1:1 관계 (외래 키)
 
     @PrePersist

--- a/server/src/main/java/com/wap/wapor/domain/VirtualAccount.java
+++ b/server/src/main/java/com/wap/wapor/domain/VirtualAccount.java
@@ -1,0 +1,38 @@
+package com.wap.wapor.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+public class VirtualAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long accountId; // 계좌 ID (Primary Key)
+
+    @Column(nullable = false)
+    private Long balance; // 잔액 (기본값 0)
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createAt; // 생성 시간
+
+    @Column(nullable = true)
+    private LocalDateTime updateAt; // 갱신 시간
+
+    @OneToOne
+    @JoinColumn(name = "userId", nullable = false, unique = true)
+    private User user; // User 테이블과 1:1 관계 (외래 키)
+
+    @PrePersist
+    protected void onCreate() {
+        this.createAt = LocalDateTime.now();
+        this.balance = 0L; // 기본 잔액 설정
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updateAt = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/wap/wapor/dto/DepositRequest.java
+++ b/server/src/main/java/com/wap/wapor/dto/DepositRequest.java
@@ -1,0 +1,10 @@
+package com.wap.wapor.dto;
+
+import lombok.Data;
+
+@Data
+public class DepositRequest {
+    private Long amount;
+    private Long accountId;
+    private String identifier;
+}

--- a/server/src/main/java/com/wap/wapor/repository/TransactionRepository.java
+++ b/server/src/main/java/com/wap/wapor/repository/TransactionRepository.java
@@ -1,0 +1,7 @@
+package com.wap.wapor.repository;
+
+import com.wap.wapor.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+}

--- a/server/src/main/java/com/wap/wapor/repository/UserRepository.java
+++ b/server/src/main/java/com/wap/wapor/repository/UserRepository.java
@@ -5,7 +5,7 @@ import com.wap.wapor.domain.UserType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByIdentifier(String identifier);
     Optional<User> findByIdentifierAndUserType(String identifier, UserType usertype);
     // identifier 중복 여부 확인 메서드

--- a/server/src/main/java/com/wap/wapor/repository/VirtualAccountRepository.java
+++ b/server/src/main/java/com/wap/wapor/repository/VirtualAccountRepository.java
@@ -1,0 +1,7 @@
+package com.wap.wapor.repository;
+
+import com.wap.wapor.domain.VirtualAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VirtualAccountRepository extends JpaRepository<VirtualAccount, Long> {
+}

--- a/server/src/main/java/com/wap/wapor/service/VirtualAccountService.java
+++ b/server/src/main/java/com/wap/wapor/service/VirtualAccountService.java
@@ -1,0 +1,50 @@
+package com.wap.wapor.service;
+
+import com.wap.wapor.domain.Transaction;
+import com.wap.wapor.domain.TransactionType;
+import com.wap.wapor.domain.User;
+import com.wap.wapor.domain.VirtualAccount;
+import com.wap.wapor.repository.TransactionRepository;
+import com.wap.wapor.repository.UserRepository;
+import com.wap.wapor.repository.VirtualAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VirtualAccountService {
+
+    private final VirtualAccountRepository virtualAccountRepository;
+    private final TransactionRepository transactionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public VirtualAccount deposit(Long accountId, Long amount, String identifier) {
+        // User 존재 확인
+        User user = userRepository.findById(identifier)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with identifier: " + identifier));
+
+        // VirtualAccount 조회
+        VirtualAccount virtualAccount = virtualAccountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found with ID: " + accountId));
+
+        // User와 VirtualAccount 연결 확인
+        if (!virtualAccount.getUser().equals(user)) {
+            throw new IllegalArgumentException("Virtual account does not belong to the user with identifier: " + identifier);
+        }
+
+        // 잔액 업데이트
+        virtualAccount.setBalance(virtualAccount.getBalance() + amount);
+
+        // 거래 기록 저장
+        Transaction transaction = new Transaction();
+        transaction.setVirtualAccount(virtualAccount);
+        transaction.setTransactionType(TransactionType.DEPOSIT);
+        transaction.setAmount(amount);
+        transactionRepository.save(transaction);
+
+        // VirtualAccount 업데이트 저장
+        return virtualAccountRepository.save(virtualAccount);
+    }
+}


### PR DESCRIPTION
### #️⃣ Related Issue
해결한 이슈 번호 
> ex) #이슈번호, #이슈번호

#33 
### 📝 Key Changes 
주요 구현 사항
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

postman 200ok 응답 내용
```JSON
{
    "accountId": 1,
    "balance": 5000,
    "createAt": "2024-11-18T17:33:25.460062",
    "updateAt": "2024-11-18T17:34:44.712878",
    "user": {
        "identifier": "3o920@naver.com",
        "userType": "EMAIL",
        "password": "$2a$10$dUgvL28DigRnJICtik2o9efTtoMyWXEcJk.A6cl2q4zTv0xQDGrk6",
        "nickname": "3o920",
        "refreshToken": null,
        "createdAt": "2024-11-18T17:33:25.390894",
        "lastLogin": null,
        "payLogs": [],
        "likes": []
    }
}
```
- (이메일) 회원 가입 시 자동으로 계좌 1개가 부여됨(`accountId`)
- 사용자가 일정 금액 입금 시 데이터베이스에 저장(`balance`)

**리팩토링 사항**
- 실제 데이터베이스 필드와 엔티티 필드 간 상이한 부분이 있어서 올바르게 매핑
- 유저 엔티티의 `userId` 필드 삭제 후 `identifier`을 PK로 지정


### 💬 To Reviewers
리뷰어에게 전달할 말
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

현재 입금만 가능하고 출금은 페이로그와 연동이 필요해서 다른 브랜치에서 작업해서 올리겠습니다!