### PR TITLE
Feature/#37/virtual account withdraw

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.eclipse.angus:jakarta.mail:1.0.0'
 
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/server/src/main/java/com/wap/wapor/config/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/wap/wapor/config/JwtAuthenticationFilter.java
@@ -25,23 +25,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String jwt = getJwtFromRequest(request);
+        try {
+            // 요청에서 JWT 토큰 추출
+            String jwt = getJwtFromRequest(request);
 
-        if (tokenProvider.validateToken(jwt)) {
-            // JWT 토큰에서 사용자 ID 추출
-            String userId = tokenProvider.getUserIdFromJWT(jwt);
+            // JWT 유효성 검사 및 사용자 식별자 추출
+            if (jwt != null && tokenProvider.validateToken(jwt)) {
+                String userId = tokenProvider.getUserIdFromJWT(jwt);
 
-            // UserPrincipal 객체 생성 (권한 없이)
-            UserPrincipal userPrincipal = new UserPrincipal(userId, null);
+                // UserPrincipal 객체 생성
+                UserPrincipal userPrincipal = new UserPrincipal(userId, null);
 
-            // SecurityContext에 인증 객체 설정 (빈 권한 리스트 사용)
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                // SecurityContext에 인증 정보 설정
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userPrincipal, null, Collections.emptyList());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception ex) {
+            // 인증 실패 시 로그 출력
+            logger.error("Failed to set user authentication in security context", ex);
         }
 
+        // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 

--- a/server/src/main/java/com/wap/wapor/controller/PayLogController.java
+++ b/server/src/main/java/com/wap/wapor/controller/PayLogController.java
@@ -3,6 +3,7 @@ package com.wap.wapor.controller;
 import com.wap.wapor.dto.PostPayLogDto;
 import com.wap.wapor.security.UserPrincipal;
 import com.wap.wapor.service.PayLogService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,8 +22,7 @@ public class PayLogController {
 
     @PostMapping
     public ResponseEntity<Long> createPayLog(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody PostPayLogDto postPayLogDto) {
-       Long postId= payLogService.payLogPost(postPayLogDto, userPrincipal);
-       return ResponseEntity.ok(postId);
-
+       Long payLogId= payLogService.createPayLog(postPayLogDto, userPrincipal);
+       return ResponseEntity.ok(payLogId);
     }
 }

--- a/server/src/main/java/com/wap/wapor/controller/VirtualAccountController.java
+++ b/server/src/main/java/com/wap/wapor/controller/VirtualAccountController.java
@@ -2,7 +2,9 @@ package com.wap.wapor.controller;
 
 import com.wap.wapor.domain.VirtualAccount;
 import com.wap.wapor.dto.DepositRequest;
+import com.wap.wapor.dto.DepositResponse;
 import com.wap.wapor.service.VirtualAccountService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,12 +17,17 @@ public class VirtualAccountController {
     private final VirtualAccountService virtualAccountService;
 
     @PostMapping("/deposit")
-    public ResponseEntity<VirtualAccount> deposit(@RequestBody DepositRequest request) {
+    public ResponseEntity<DepositResponse> deposit(@Valid @RequestBody DepositRequest request) {
         VirtualAccount updatedAccount = virtualAccountService.deposit(
                 request.getAccountId(),
                 request.getAmount(),
                 request.getIdentifier()
         );
-        return ResponseEntity.ok(updatedAccount);
+
+        DepositResponse response = new DepositResponse();
+        response.setAccountId(updatedAccount.getAccountId());
+        response.setNewBalance(updatedAccount.getBalance());
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/server/src/main/java/com/wap/wapor/dto/DepositRequest.java
+++ b/server/src/main/java/com/wap/wapor/dto/DepositRequest.java
@@ -1,9 +1,11 @@
 package com.wap.wapor.dto;
 
+import jakarta.validation.constraints.Min;
 import lombok.Data;
 
 @Data
 public class DepositRequest {
+    @Min(value = 1, message = "입금 금액은 0보다 커야 합니다.")
     private Long amount;
     private Long accountId;
     private String identifier;

--- a/server/src/main/java/com/wap/wapor/dto/DepositResponse.java
+++ b/server/src/main/java/com/wap/wapor/dto/DepositResponse.java
@@ -1,0 +1,9 @@
+package com.wap.wapor.dto;
+
+import lombok.Data;
+
+@Data
+public class DepositResponse {
+    private Long accountId;
+    private Long newBalance;
+}

--- a/server/src/main/java/com/wap/wapor/repository/UserRepository.java
+++ b/server/src/main/java/com/wap/wapor/repository/UserRepository.java
@@ -3,11 +3,20 @@ package com.wap.wapor.repository;
 import com.wap.wapor.domain.User;
 import com.wap.wapor.domain.UserType;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
+    // identifier로 사용자 조회
     Optional<User> findByIdentifier(String identifier);
-    Optional<User> findByIdentifierAndUserType(String identifier, UserType usertype);
-    // identifier 중복 여부 확인 메서드
+
+    // identifier와 userType으로 사용자 조회
+    Optional<User> findByIdentifierAndUserType(String identifier, UserType userType);
+
+    // identifier 중복 여부 확인
     boolean existsByIdentifier(String identifier);
+
+    // identifier와 여러 userType으로 사용자 조회
+    Optional<User> findByIdentifierAndUserTypeIn(String identifier, List<UserType> userTypes);
 }

--- a/server/src/main/java/com/wap/wapor/repository/VirtualAccountRepository.java
+++ b/server/src/main/java/com/wap/wapor/repository/VirtualAccountRepository.java
@@ -1,7 +1,12 @@
 package com.wap.wapor.repository;
 
+import com.wap.wapor.domain.User;
 import com.wap.wapor.domain.VirtualAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+@Repository
 public interface VirtualAccountRepository extends JpaRepository<VirtualAccount, Long> {
+    Optional<VirtualAccount> findByUser(User user);
 }

--- a/server/src/main/java/com/wap/wapor/service/PayLogService.java
+++ b/server/src/main/java/com/wap/wapor/service/PayLogService.java
@@ -3,35 +3,64 @@ package com.wap.wapor.service;
 import com.wap.wapor.domain.PayLog;
 import com.wap.wapor.domain.User;
 import com.wap.wapor.domain.UserType;
+import com.wap.wapor.domain.VirtualAccount;
 import com.wap.wapor.dto.PostPayLogDto;
 import com.wap.wapor.repository.PayLogRepository;
 import com.wap.wapor.repository.UserRepository;
+import com.wap.wapor.repository.VirtualAccountRepository;
 import com.wap.wapor.security.UserPrincipal;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class PayLogService {
-        private final PayLogRepository payLogRepository;
-        private final UserRepository userRepository;
-        public PayLogService(PayLogRepository payLogRepository, UserRepository userRepository) {
-            this.payLogRepository = payLogRepository;
-            this.userRepository = userRepository;
+
+    private final PayLogRepository payLogRepository;
+    private final UserRepository userRepository;
+    private final VirtualAccountRepository virtualAccountRepository;
+
+    @Transactional
+    public Long createPayLog(PostPayLogDto postPayLogDto, UserPrincipal userPrincipal) {
+        // KAKAO와 EMAIL 두 가지 유형을 허용
+        List<UserType> allowedUserTypes = Arrays.asList(UserType.KAKAO, UserType.EMAIL);
+
+        // identifier와 userType 목록으로 사용자 조회
+        User user = userRepository.findByIdentifierAndUserTypeIn(userPrincipal.getId(), allowedUserTypes)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        VirtualAccount virtualAccount = virtualAccountRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("가상계좌를 찾을 수 없습니다."));
+
+        if (postPayLogDto.getAmount() == null || postPayLogDto.getAmount() <= 0) {
+            throw new IllegalArgumentException("출금 금액은 0보다 커야 합니다.");
         }
-    public Long payLogPost(PostPayLogDto postPayLogDto, UserPrincipal userPrincipal) {
-        Optional<User> user=userRepository.findByIdentifierAndUserType(userPrincipal.getId(), UserType.KAKAO);
-        PayLog payLog=new PayLog();
-        payLog.setAmount(postPayLogDto.getAmount());
+
+        if (virtualAccount.getBalance() < postPayLogDto.getAmount()) {
+            throw new IllegalArgumentException("잔액이 부족합니다.");
+        }
+
+        virtualAccount.setBalance(virtualAccount.getBalance() - postPayLogDto.getAmount());
+        virtualAccountRepository.save(virtualAccount);
+
+        PayLog payLog = new PayLog();
+        payLog.setUser(user);
+        payLog.setAmount(postPayLogDto.getAmount()); // 출금 금액
         payLog.setCategory(postPayLogDto.getCategory());
         payLog.setContent(postPayLogDto.getContent());
         payLog.setTitle(postPayLogDto.getTitle());
-        payLog.setCreatedAt(LocalDateTime.now());
         payLog.setImgUrl(postPayLogDto.getImgUrl());
-        payLog.setUser(user.get());
+        payLog.setCreatedAt(LocalDateTime.now());
         payLog.setLikeCount(0);
-        PayLog payLogResult=payLogRepository.save(payLog);
-        return payLogResult.getId();
+
+        PayLog savedPayLog = payLogRepository.save(payLog);
+
+        return savedPayLog.getId(); // 생성된 페이로그 ID 반환
     }
 }

--- a/server/src/main/java/com/wap/wapor/service/VirtualAccountService.java
+++ b/server/src/main/java/com/wap/wapor/service/VirtualAccountService.java
@@ -21,6 +21,11 @@ public class VirtualAccountService {
 
     @Transactional
     public VirtualAccount deposit(Long accountId, Long amount, String identifier) {
+
+        if (amount == null || amount <= 0) {
+            throw new IllegalArgumentException("입금 금액은 0보다 커야 합니다.");
+        }
+
         // User 존재 확인
         User user = userRepository.findById(identifier)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with identifier: " + identifier));


### PR DESCRIPTION
### #️⃣ Related Issue
해결한 이슈 번호 
> ex) #이슈번호, #이슈번호

#37 

### 📝 Key Changes 
주요 구현 사항
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

페이로그 등록과 가상계좌 출금을 연동했습니다. 
페이로그 등록 시 카카오 유저만 가능하도록 검사했던 부분 이메일도 포함시켰고, 페이로그 등록 전 해당 사용자에게 가상계좌가 있는지 확인하는 로직 추가했습니다. 

### 💬 To Reviewers
리뷰어에게 전달할 말
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

paylogservice 등 페이로그 관련 클래스들 변경 사항 있으니 충돌 안 나게 확인 부탁드립니다.